### PR TITLE
Updated bufread() to allow readout of histogram memory.

### DIFF
--- a/src/wib_util.cc
+++ b/src/wib_util.cc
@@ -124,6 +124,7 @@ void cdpoke(uint8_t femb_idx, uint8_t chip_addr, uint8_t reg_page, uint8_t reg_a
 //HERMES
 void bufread(char* dest, size_t buf_num) { ///FOR NEW FIRMWARE
 	size_t daq_spy_addr;
+	size_t buf_size = DAQ_SPY_SIZE; //default 									   
 	
 	if (buf_num==0) daq_spy_addr = DAQ_SPY_FEMB0_CD0;
 	else if (buf_num==1) daq_spy_addr = DAQ_SPY_FEMB0_CD1;
@@ -133,18 +134,22 @@ void bufread(char* dest, size_t buf_num) { ///FOR NEW FIRMWARE
 	else if (buf_num==5) daq_spy_addr = DAQ_SPY_FEMB2_CD1;
 	else if (buf_num==6) daq_spy_addr = DAQ_SPY_FEMB3_CD0;
 	else if (buf_num==7) daq_spy_addr = DAQ_SPY_FEMB3_CD1;
+	else if (buf_num==8) {
+		daq_spy_addr = DAQ_HISTOGRAM; /// new for ADC QC firmware
+		buf_size = HIST_MEM_SIZE; /// reassign size for histogram option
+	}					   
 	else return;    
 	
 	//see WIB_upgrade::WIB_upgrade		
     int daq_spy_fd = open("/dev/mem",O_RDWR); // File descriptor for the daq spy mapped memory    
-    void *daq_spy = mmap(NULL,DAQ_SPY_SIZE,PROT_READ,MAP_SHARED,daq_spy_fd,daq_spy_addr); // Pointer to the daq spy firmware buffers
+    void *daq_spy = mmap(NULL,buf_size,PROT_READ,MAP_SHARED,daq_spy_fd,daq_spy_addr); // Pointer to the daq spy firmware buffers
 	
 	close(daq_spy_fd); //"After mmap() call has returned, fd can be closed immediately without invalidating the mapping.
 	if (daq_spy == MAP_FAILED) return; //mmap failed
 	
-	memcpy(dest, daq_spy, DAQ_SPY_SIZE);
+	memcpy(dest, daq_spy, buf_size);
 	
-	munmap(daq_spy,DAQ_SPY_SIZE); 
+	munmap(daq_spy,buf_size); 
 }
 
 uint8_t i2cread(uint8_t bus, uint8_t chip, uint8_t reg) {

--- a/src/wib_util.h
+++ b/src/wib_util.h
@@ -22,6 +22,7 @@ extern "C" {
 	constexpr size_t CTRL_REGS              = 0xA00C0000;
 	//constexpr size_t DAQ_SPY_0              = 0xA0100000;
 	//constexpr size_t DAQ_SPY_1              = 0xA0200000;
+	constexpr size_t DAQ_HISTOGRAM 				 = 0xA00C8000; /// <- ADC QC firmware																	 
 	constexpr size_t DAQ_SPY_FEMB0_CD0           = 0x440000000; ///new fw, these replace DAQ_SPY_0
 	constexpr size_t DAQ_SPY_FEMB0_CD1           = 0x440100000; ///and DAQ_SPY_1
 	constexpr size_t DAQ_SPY_FEMB1_CD0           = 0x440200000;
@@ -49,6 +50,7 @@ extern "C" {
 	//Size of a DAQ spy buffer
 	//constexpr size_t DAQ_SPY_SIZE           = 0x00100000;
 	constexpr size_t DAQ_SPY_SIZE           	 = 0x40000; ///new fw, replaces old DAQ_SPY_SIZE
+	constexpr size_t HIST_MEM_SIZE				 = 0x8000; /// <- ADC QC firmware																
 
 	////////////FROM FEMB_3ASIC.H:
 


### PR DESCRIPTION
File changes:
wib_util.cc: Modified bufread to accept buf_num=8 to mean readout and return contents of histogram memory.
wib_util.h: Added constants for histogram memory location and size.